### PR TITLE
Turn all error variants into records for extendability 

### DIFF
--- a/icrcX.did
+++ b/icrcX.did
@@ -23,15 +23,15 @@ type NotifyResult = record {
 type NotifyResponse = variant {
   Ok : NotifyResult;
   Err : variant {
-    CallLedgerError : text;
-    NotAvailable : text;
+    CallLedgerError : record { message : text };
+    NotAvailable : record { message : text };
   };
 };
 
 type BalanceResponse = variant {
   Ok : Amount;
   Err : variant {
-    NotAvailable : text;
+    NotAvailable : record { message : text };
   };
 };
 
@@ -47,9 +47,9 @@ type WithdrawResponse = variant {
     amount : Amount;
   };
   Err : variant {
-    CallLedgerError : text;
-    InsufficientCredit;
-    AmountBelowMinimum;
+    CallLedgerError : record { message : text };
+    InsufficientCredit : record {};
+    AmountBelowMinimum : record {};
   };
 };
 
@@ -68,9 +68,9 @@ type DepositResult = record {
 type DepositResponse = variant {
   Ok : DepositResult;
   Err : variant {
-    AmountBelowMinimum;
-    CallLedgerError : text;
-    TransferError : text; // insufficient allowance or insufficient funds
+    AmountBelowMinimum : record {};
+    CallLedgerError : record { message : text };
+    TransferError : record { message : text }; // insufficient allowance or insufficient funds
   };
 };
 

--- a/icrcX.md
+++ b/icrcX.md
@@ -195,8 +195,8 @@ type NotifyResult = variant {
     credit : int;
   }; 
   Err : variant {
-    CallLedgerError : text;
-    NotAvailable : text;
+    CallLedgerError : record { message : text };
+    NotAvailable : record { message : text };
   };
 };
 ```
@@ -264,7 +264,7 @@ Otherwise the method the returns the following type.
 type BalanceResult = variant {
   Ok : Amount;
   Err : variant {
-    NotAvailable : text;
+    NotAvailable : record { message : text };
   };
 };
 ```
@@ -321,9 +321,9 @@ If successful, the call returns:
 type DepositResponse = variant {
   Ok : DepositResult;
   Err : variant {
-    AmountBelowMinimum;
-    CallLedgerError : text;
-    TransferError : text; // insufficient allowance or insufficient funds
+    AmountBelowMinimum : record {};
+    CallLedgerError : record { message : text };
+    TransferError : record { message : text }; // insufficient allowance or insufficient funds
   };
 };
 
@@ -375,9 +375,9 @@ type WithdrawResult = variant {
     amount : Amount;
   };
   Err : variant {
-    InsufficientCredit;
-    AmountBelowMinimum;
-    CallLedgerError : text;
+    InsufficientCredit : record {};
+    AmountBelowMinimum : record {};
+    CallLedgerError : record { message : text };
   };
 };
 ```


### PR DESCRIPTION
In the future more details can be returned about an error by
adding more fields to the record.